### PR TITLE
Fix hash variable scope

### DIFF
--- a/tootoo/2025-06-09/gfo/github-file-open.js
+++ b/tootoo/2025-06-09/gfo/github-file-open.js
@@ -2,7 +2,8 @@ let divContent;
 
 function onHashChange() {
 
-  COR.hash = hash = location.hash.slice(1);
+  let hash = location.hash.slice(1);
+  COR.hash = hash;
   
   divContent = COR.divContent;
 


### PR DESCRIPTION
## Summary
- fix `hash` leaking to global scope in `github-file-open.js`

## Testing
- `node --check tootoo/2025-06-09/gfo/github-file-open.js`


------
https://chatgpt.com/codex/tasks/task_e_6847b8aaa80c8327a56503b14c5af608